### PR TITLE
Remove delete previous tag in the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,15 +54,15 @@ jobs:
             --push \
             .
 
-      - name: Delete previous tag
-        run: |
-          IFS='.' read -r MAJOR MINOR PATCH <<< "${{steps.get_tag.outputs.VERSION}}"
-          PREV_PATCH=$((PATCH - 1))
-          PREV_TAG="v$MAJOR.$MINOR.$PREV_PATCH"
+      # - name: Delete previous tag
+      #   run: |
+      #     IFS='.' read -r MAJOR MINOR PATCH <<< "${{steps.get_tag.outputs.VERSION}}"
+      #     PREV_PATCH=$((PATCH - 1))
+      #     PREV_TAG="v$MAJOR.$MINOR.$PREV_PATCH"
           
-          git tag --delete ${PREV_TAG}
-          git push "${{ env.remote_repo }}" --delete ${PREV_TAG}
-          git tag -l
+      #     git tag --delete ${PREV_TAG}
+      #     git push "${{ env.remote_repo }}" --delete ${PREV_TAG}
+      #     git tag -l
 
       - name: Update tag
         id: updated_tag


### PR DESCRIPTION
Since I'm gonna do some modifications to app, I don't want to ruin the previous running version. Delete the delete tag job in the workflow and it passed action test so should be fine. I'll directly merge it.